### PR TITLE
Better failover suitability, promisified. And lock extension.

### DIFF
--- a/lib/ioredfour.js
+++ b/lib/ioredfour.js
@@ -101,7 +101,7 @@ function Lock(options) {
 
 Object.assign(Lock.prototype, {
     /**
-     * Acquire a lock for a specific ID value. Callback returns the following value:
+     * Acquire a lock for a specific ID value. Returns promise that resolves to the following value:
      *
      *   {
      *     success: either true (lock was acquired) of false (lock was not aquired)
@@ -114,22 +114,14 @@ Object.assign(Lock.prototype, {
      * @param {String} id Identifies the lock. This is an arbitrary string that should be consistent among
      *    different processes trying to acquire this lock.
      * @param {Number} ttl Automatically release lock after TTL (ms). Must be positive integer
-     * @param {Function} done Callback
      */
-    acquireLock(id, ttl, done) {
-        this._redisConnection.acquireLock(`${this._namespace}:${id}`, `${this._namespace}index`, ttl, (err, evalResponse) => {
-            if (err) {
-                return done(err);
-            }
-
-            let response = {
-                id,
-                success: !!evalResponse[0],
-                index: evalResponse[1],
-                ttl: evalResponse[2]
-            };
-            done(null, response);
-        });
+   acquireLock(id, ttl) {
+        return this._redisConnection.acquireLock(`${this._namespace}:${id}`, `${this._namespace}index`, ttl).then(evalResponse => ({
+            id,
+            success: !!evalResponse[0],
+            index: evalResponse[1],
+            ttl: evalResponse[2]
+        }));
     },
 
     /**
@@ -138,7 +130,7 @@ Object.assign(Lock.prototype, {
      * lock was expired in the meantime and someone has already acquired a new lock for the same id.
      * If lock is not released manually then it expires automatically after the ttl
      *
-     * Callback returns the following value:
+     * Returns promise that resolves to the following value:
      *
      *   {
      *     success: either true (lock was released or did not exist) of false (lock was not released)
@@ -146,27 +138,20 @@ Object.assign(Lock.prototype, {
      *   }
      *
      * @param {Object} lock A lock returned by acquireLock or waitAcquireLock
-     * @param {Function} done Callback
      */
-    releaseLock(lock, done) {
-        this._redisConnection.releaseLock(`${this._namespace}:${lock.id}`, lock.index, (err, evalResponse) => {
-            if (err) {
-                return done(err);
-            }
-
-            let response = {
-                id: lock.id,
-                success: !!evalResponse[0],
-                result: evalResponse[1],
-                index: evalResponse[2]
-            };
-            done(null, response);
-        });
+    releaseLock(lock) {
+        return this._redisConnection.releaseLock(`${this._namespace}:${lock.id}`, lock.index).then(evalResponse => ({
+            id: lock.id,
+            success: !!evalResponse[0],
+            result: evalResponse[1],
+            index: evalResponse[2]
+        }));
     },
 
     /**
      * Acquire a lock for a specific ID value. If the lock is not available then waits
-     * up to {waitTtl} milliseconds before giving up. The callback returns the following values:
+     * up to {waitTtl} milliseconds before giving up.
+     * Returns a promise that resolves to the following value:
      *
      *   {
      *     success: either true (lock was acquired) of false (lock was not aquired by given ttl)
@@ -177,58 +162,58 @@ Object.assign(Lock.prototype, {
      *    different processes trying to acquire this lock.
      * @param {Number} ttl Automatically release acquired lock after TTL (ms). Must be positive integer
      * @param {Number} waitTtl Give up until ttl (in ms) or wait indefinitely if value is 0
-     * @param {Function} done Callback
      */
-    waitAcquireLock(id, lockTtl, waitTtl, done) {
-        let expired = false; // flag to indicate that the TTL wait time was expired
-        let acquiring = false; // flag to indicate that a Redis query is in process
+    waitAcquireLock(id, lockTtl, waitTtl) {
+        return new Promise((resolve, reject) => {
+            let expired = false; // flag to indicate that the TTL wait time was expired
+            let acquiring = false; // flag to indicate that a Redis query is in process
 
-        let ttlTimer;
-        let expireLockTimer;
+            let ttlTimer;
+            let expireLockTimer;
 
-        // A looping function that tries to acquire a lock. The loop goes on until
-        // the lock is acquired or the wait ttl kicks in
-        let tryAcquire = () => {
-            this._subscribers.removeListener(`${this._namespace}:${id}`, tryAcquire); // clears pubsub listener
-            clearTimeout(ttlTimer); // clears the timer that waits until existing lock is expired
-            acquiring = true;
-            this.acquireLock(id, lockTtl, (err, lock) => {
-                acquiring = false;
-                if (err) {
+            // A looping function that tries to acquire a lock. The loop goes on until
+            // the lock is acquired or the wait ttl kicks in
+            let tryAcquire = () => {
+                this._subscribers.removeListener(`${this._namespace}:${id}`, tryAcquire); // clears pubsub listener
+                clearTimeout(ttlTimer); // clears the timer that waits until existing lock is expired
+                acquiring = true;
+                this.acquireLock(id, lockTtl).then(lock => {
+                    acquiring = false;
+                    if (lock.success || expired) {
+                        // we got a lock or the wait TTL was expired, return what we have
+                        clearTimeout(expireLockTimer);
+                        return resolve(lock);
+                    }
+
+                    // Wait for either a Redis publish event or for the lock expiration timer to expire
+                    this._subscribers.addListener(`${this._namespace}:${id}`, tryAcquire);
+                    // Remaining TTL for the lock might be very low, even 0 (lock expires by next ms)
+                    // in any case we do not make a next polling try sooner than after 100ms delay
+                    // We might make the call sooner if the key is released manually and we get a notification
+                    // from Redis PubSub about it
+                    ttlTimer = setTimeout(tryAcquire, Math.max(lock.ttl, 100));
+                }).catch(err => {
                     // stop waiting if we hit into an error
                     clearTimeout(expireLockTimer);
-                    return done(err);
-                }
-                if (lock.success || expired) {
-                    // we got a lock or the wait TTL was expired, return what we have
-                    clearTimeout(expireLockTimer);
-                    return done(null, lock);
-                }
+                    return reject(err);
+                });
+            };
 
-                // Wait for either a Redis publish event or for the lock expiration timer to expire
-                this._subscribers.addListener(`${this._namespace}:${id}`, tryAcquire);
-                // Remaining TTL for the lock might be very low, even 0 (lock expires by next ms)
-                // in any case we do not make a next polling try sooner than after 100ms delay
-                // We might make the call sooner if the key is released manually and we get a notification
-                // from Redis PubSub about it
-                ttlTimer = setTimeout(tryAcquire, Math.max(lock.ttl, 100));
-            });
-        };
+            if (waitTtl > 0) {
+                expireLockTimer = setTimeout(() => {
+                    expired = true;
+                    this._subscribers.removeListener(`${this._namespace}:${id}`, tryAcquire);
+                    clearTimeout(ttlTimer);
+                    // Try one last time and return whatever the acquireLock returns
+                    if (!acquiring) {
+                        return tryAcquire();
+                    }
+                }, waitTtl);
+            }
 
-        if (waitTtl > 0) {
-            expireLockTimer = setTimeout(() => {
-                expired = true;
-                this._subscribers.removeListener(`${this._namespace}:${id}`, tryAcquire);
-                clearTimeout(ttlTimer);
-                // Try one last time and return whatever the acquireLock returns
-                if (!acquiring) {
-                    return tryAcquire();
-                }
-            }, waitTtl);
-        }
-
-        // try to acquire a lock
-        tryAcquire();
+            // try to acquire a lock
+            tryAcquire();
+        });
     }
 });
 

--- a/lib/ioredfour.js
+++ b/lib/ioredfour.js
@@ -13,12 +13,14 @@ const EventEmitter = require('events').EventEmitter;
  *   @property {Object} redisConnection Pre-existing Redis connection.
  *   @property {String=} namespace - An optional namespace under which to prefix all Redis keys and
  *     channels used by this lock.
+ *   @property {Int} minReplications - write must to be replicated at least this many times
+ *   @property {Int} replicationTimeout - Wait at most this many miliseconds for replication.
+ *     Set to 0 to wait with no timeout.
  */
 function Lock(options) {
-    options = options || {};
-    options.namespace = options.namespace || 'lock';
-
-    this._namespace = options.namespace;
+    this._namespace = options.namespace || 'lock';
+    this._minReplications = options.minReplications || 0;
+    this._replicationTimeout = options.replicationTimeout || 500;
 
     // Create Redis connection for issuing normal commands as well as one for
     // the subscription, since a Redis connection with subscribers is not allowed
@@ -76,6 +78,22 @@ function Lock(options) {
         lua: acquireScript
     });
 
+    let extendScript = `
+        local ttl = tonumber(ARGV[2]);
+        local index = tonumber(ARGV[1]);
+        if redis.call("HGET", KEYS[1], "index") == ARGV[1] then
+            redis.call("PEXPIRE", KEYS[1], ttl);
+            return {1, index, ttl};
+        else
+            return {0};
+        end;
+    `;
+
+    this._redisConnection.defineCommand('extendLock', {
+        numberOfKeys: 1,
+        lua: extendScript
+    });
+
     let releaseScript = `
         local index = tonumber(ARGV[1]);
         if redis.call("EXISTS", KEYS[1]) == 0 then
@@ -116,12 +134,27 @@ Object.assign(Lock.prototype, {
      * @param {Number} ttl Automatically release lock after TTL (ms). Must be positive integer
      */
    acquireLock(id, ttl) {
-        return this._redisConnection.acquireLock(`${this._namespace}:${id}`, `${this._namespace}index`, ttl).then(evalResponse => ({
-            id,
-            success: !!evalResponse[0],
-            index: evalResponse[1],
-            ttl: evalResponse[2]
-        }));
+        return this._redisConnection
+            .pipeline()
+            .acquireLock(`${this._namespace}:${id}`, `${this._namespace}index`, ttl)
+            .wait(this._minReplications, this._replicationTimeout)
+            .exec()
+            .then(([[evalErr, evalResponse], [repErr, replications]]) => {
+                if (evalErr) {
+                    throw evalErr || repErr;
+                }
+                const lock = {
+                    id,
+                    success: replications >= this._minReplications && !!evalResponse[0],
+                    index: evalResponse[1],
+                    ttl: evalResponse[2]
+                };
+                if (replications < this._minReplications) {
+                    lock.replicationFailure = true;
+                    this._redisConnection.releaseLock(lock)
+                }
+                return lock;
+            });
     },
 
     /**
@@ -145,6 +178,22 @@ Object.assign(Lock.prototype, {
             success: !!evalResponse[0],
             result: evalResponse[1],
             index: evalResponse[2]
+        }));
+    },
+
+
+    /**
+     * Extends that TTL for a lock that is already owned.
+     * Fails if modification index in lock provided is not currently holding the lock.
+     * @param lock
+     * @param ttl
+     */
+    extendLock(lock, ttl) {
+        return this._redisConnection.extendLock(`${this._namespace}:${lock.id}`, lock.index, ttl).then(evalResponse => ({
+            id: lock.id,
+            success: !!evalResponse[0],
+            index: evalResponse[1],
+            ttl: evalResponse[2]
         }));
     },
 

--- a/lib/ioredfour.js
+++ b/lib/ioredfour.js
@@ -1,5 +1,5 @@
 'use strict';
-
+const callbackify = require('util').callbackify;
 const assert = require('assert');
 const Redis = require('ioredis');
 const EventEmitter = require('events').EventEmitter;
@@ -133,7 +133,10 @@ Object.assign(Lock.prototype, {
      *    different processes trying to acquire this lock.
      * @param {Number} ttl Automatically release lock after TTL (ms). Must be positive integer
      */
-   acquireLock(id, ttl) {
+    acquireLock(id, ttl, cb) {
+        if (cb) {
+            return callbackify(this.acquireLock).apply(this, arguments);
+        }
         return this._redisConnection
             .pipeline()
             .acquireLock(`${this._namespace}:${id}`, `${this._namespace}index`, ttl)
@@ -172,7 +175,10 @@ Object.assign(Lock.prototype, {
      *
      * @param {Object} lock A lock returned by acquireLock or waitAcquireLock
      */
-    releaseLock(lock) {
+    releaseLock(lock, cb) {
+        if (cb) {
+            return callbackify(this.releaseLock).apply(this, arguments);
+        }
         return this._redisConnection.releaseLock(`${this._namespace}:${lock.id}`, lock.index).then(evalResponse => ({
             id: lock.id,
             success: !!evalResponse[0],
@@ -188,7 +194,10 @@ Object.assign(Lock.prototype, {
      * @param lock
      * @param ttl
      */
-    extendLock(lock, ttl) {
+    extendLock(lock, ttl, cb) {
+        if (cb) {
+            return callbackify(this.extendLock).apply(this, arguments);
+        }
         return this._redisConnection.extendLock(`${this._namespace}:${lock.id}`, lock.index, ttl).then(evalResponse => ({
             id: lock.id,
             success: !!evalResponse[0],
@@ -212,7 +221,10 @@ Object.assign(Lock.prototype, {
      * @param {Number} ttl Automatically release acquired lock after TTL (ms). Must be positive integer
      * @param {Number} waitTtl Give up until ttl (in ms) or wait indefinitely if value is 0
      */
-    waitAcquireLock(id, lockTtl, waitTtl) {
+    waitAcquireLock(id, lockTtl, waitTtl, cb) {
+        if (cb) {
+            return callbackify(this.waitAcquireLock).apply(this, arguments);
+        }
         return new Promise((resolve, reject) => {
             let expired = false; // flag to indicate that the TTL wait time was expired
             let acquiring = false; // flag to indicate that a Redis query is in process

--- a/lib/ioredfour.js
+++ b/lib/ioredfour.js
@@ -133,8 +133,8 @@ Object.assign(Lock.prototype, {
      *    different processes trying to acquire this lock.
      * @param {Number} ttl Automatically release lock after TTL (ms). Must be positive integer
      */
-    acquireLock(id, ttl, cb) {
-        if (cb) {
+    acquireLock(id, ttl) {
+        if (arguments.length > 2) {
             return callbackify(this.acquireLock).apply(this, arguments);
         }
         return this._redisConnection
@@ -175,8 +175,8 @@ Object.assign(Lock.prototype, {
      *
      * @param {Object} lock A lock returned by acquireLock or waitAcquireLock
      */
-    releaseLock(lock, cb) {
-        if (cb) {
+    releaseLock(lock) {
+        if (arguments.length > 1) {
             return callbackify(this.releaseLock).apply(this, arguments);
         }
         return this._redisConnection.releaseLock(`${this._namespace}:${lock.id}`, lock.index).then(evalResponse => ({
@@ -194,8 +194,8 @@ Object.assign(Lock.prototype, {
      * @param lock
      * @param ttl
      */
-    extendLock(lock, ttl, cb) {
-        if (cb) {
+    extendLock(lock, ttl) {
+        if (arguments.length > 2) {
             return callbackify(this.extendLock).apply(this, arguments);
         }
         return this._redisConnection.extendLock(`${this._namespace}:${lock.id}`, lock.index, ttl).then(evalResponse => ({
@@ -221,8 +221,8 @@ Object.assign(Lock.prototype, {
      * @param {Number} ttl Automatically release acquired lock after TTL (ms). Must be positive integer
      * @param {Number} waitTtl Give up until ttl (in ms) or wait indefinitely if value is 0
      */
-    waitAcquireLock(id, lockTtl, waitTtl, cb) {
-        if (cb) {
+    waitAcquireLock(id, lockTtl, waitTtl) {
+        if (arguments.length > 3) {
             return callbackify(this.waitAcquireLock).apply(this, arguments);
         }
         return new Promise((resolve, reject) => {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
         "mocha": "7.2.0"
     },
     "dependencies": {
-        "ioredis": "4.17.3"
+        "ioredis": "^4.19.2"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-    "name": "ioredfour",
-    "version": "1.0.2-ioredis-03",
-    "description": "A redis binary semaphore",
+    "name": "@triggi/ioredfour",
+    "version": "1.0.0-pre1",
+    "description": "A redis binary semaphore with some consistency",
     "main": "lib/ioredfour.js",
     "scripts": {
         "test": "grunt"
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/nodemailer/redfour.git"
+        "url": "git+https://github.com/olisto/ioredfour.git"
     },
     "keywords": [
         "redis",
@@ -19,9 +19,9 @@
     "author": "Mixmax <hello@mixmax.com> (https://mixmax.com/)",
     "license": "MIT",
     "bugs": {
-        "url": "https://github.com/nodemailer/redfour/issues"
+        "url": "https://github.com/olisto/ioredfour/issues"
     },
-    "homepage": "https://github.com/nodemailer/redfour#readme",
+    "homepage": "https://github.com/olisto/ioredfour#readme",
     "devDependencies": {
         "chai": "4.2.0",
         "eslint": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@triggi/ioredfour",
-    "version": "1.0.0-pre1",
+    "version": "1.1.0-pre1",
     "description": "A redis binary semaphore with some consistency",
     "main": "lib/ioredfour.js",
     "scripts": {
@@ -16,7 +16,7 @@
         "mutex",
         "node"
     ],
-    "author": "Mixmax <hello@mixmax.com> (https://mixmax.com/)",
+    "author": "Mixmax <hello@mixmax.com> (https://mixmax.com/), Daniel Reus (https://github.com/dreusel)",
     "license": "MIT",
     "bugs": {
         "url": "https://github.com/olisto/ioredfour/issues"

--- a/test/ioredfour-test.js
+++ b/test/ioredfour-test.js
@@ -47,7 +47,7 @@ describe('lock', function () {
         expect(release.success).to.equal(true);
     });
 
-    it('should wait and acquire a lock', async () => {
+    it('should wait and acquire a lock after releasing', async () => {
         const initialLock = await testLock.acquireLock(testKey, 1 * 60 * 1000);
         expect(initialLock.success).to.equal(true);
 
@@ -55,6 +55,36 @@ describe('lock', function () {
         setTimeout(() => {
             testLock.releaseLock(initialLock);
         }, 1500);
+        const newLock = await testLock.waitAcquireLock(testKey, 60 * 100, 3000);
+        expect(newLock.success).to.equal(true);
+        expect(Date.now() - start).to.be.above(1450);
+
+        await testLock.releaseLock(newLock);
+    });
+
+    it('should wait and acquire a lock after expiring', async () => {
+        const initialLock = await testLock.acquireLock(testKey, 1.5 * 1000);
+        expect(initialLock.success).to.equal(true);
+
+        let start = Date.now();
+        const newLock = await testLock.waitAcquireLock(testKey, 60 * 100, 3000);
+        expect(newLock.success).to.equal(true);
+        expect(Date.now() - start).to.be.above(1450);
+
+        await testLock.releaseLock(newLock);
+    });
+
+    it('should wait and acquire a lock after extending', async () => {
+        const initialLock = await testLock.acquireLock(testKey, 1 * 1000);
+        expect(initialLock.success).to.equal(true);
+        setTimeout(() => {
+            testLock.extendLock(initialLock, 10000);
+        }, 500);
+        setTimeout(() => {
+            testLock.releaseLock(initialLock);
+        }, 1500);
+
+        let start = Date.now();
         const newLock = await testLock.waitAcquireLock(testKey, 60 * 100, 3000);
         expect(newLock.success).to.equal(true);
         expect(Date.now() - start).to.be.above(1450);


### PR DESCRIPTION
You might be interested. If not, feel free to close.
I needed a distributed locking solution that provides a bit more consistency in a failover/sentinel environment than, well pretty much any Redis-based locking solution I could find. So I decided to take yours as a starting point. The key here is mainly to implement `acquireLock` as a pipeline that includes a `wait`. New config parameters `minReplications` and `replicationTimeout` control this, by default it's disabled.
Also 
- Promisified the API, so that it fits in our own codebase (but provided callback interfaces for backwards compatibility)
- Added an extendLock method that extends the TTL of an existing lock
- Added some tests, including one to test expiry (so useful regardless of my other additions)