### PR TITLE
Retry locking if wait fails within timeout. Reset ttl after wait.

### DIFF
--- a/lib/ioredfour.js
+++ b/lib/ioredfour.js
@@ -228,12 +228,10 @@ Object.assign(Lock.prototype, {
         if (arguments.length > 2) {
             return callbackify(this.extendLock).apply(this, arguments);
         }
-        return this._redisConnection.extendLock(`${this._namespace}:${lock.id}`, lock.index, ttl).then(evalResponse => ({
-            id: lock.id,
-            success: !!evalResponse[0],
-            index: evalResponse[1],
-            ttl: evalResponse[2]
-        }));
+        if (ttl < this._minTtl) {
+            throw new Error('ttl must be significantly longer than replicationTimeout');
+        }
+        return aquireLock.call(this, lock.id, ttl, lock.index, Date.now());
     },
 
     /**

--- a/lib/ioredfour.js
+++ b/lib/ioredfour.js
@@ -21,6 +21,8 @@ function Lock(options) {
     this._namespace = options.namespace || 'lock';
     this._minReplications = options.minReplications || 0;
     this._replicationTimeout = options.replicationTimeout || 500;
+    // We want to be sure the lock doesn't expire at the primary while still waiting for confirmation from the replicas
+    this._minTtl = this._minReplications ? this._replicationTimeout * 1.5 : 0;
 
     // Create Redis connection for issuing normal commands as well as one for
     // the subscription, since a Redis connection with subscribers is not allowed
@@ -58,7 +60,12 @@ function Lock(options) {
     let acquireScript = `
         local ttl=tonumber(ARGV[1]);
         if redis.call("EXISTS", KEYS[1]) == 1 then
-            return {0, -1, redis.call("PTTL", KEYS[1])};
+            if redis.call("HGET", KEYS[1], "index") == ARGV[2] then
+                redis.call("PEXPIRE", KEYS[1], ttl);
+                return {2, ARGV[2], ttl};
+            else
+                return {0, -1, redis.call("PTTL", KEYS[1])};
+            end
         end;
         --[[
             Use a global incrementing counter
@@ -67,20 +74,18 @@ function Lock(options) {
             boundary would be much smaller Number.MAX_SAFE_INTEGER it would take thousands
             of years to reach that limit assuming we make 100k incrementations in a second
         --]]
-        local index = redis.call("INCR", KEYS[2]);
-        redis.call("HMSET", KEYS[1], "index", index);
+        redis.call("HMSET", KEYS[1], "index", ARGV[2]);
         redis.call("PEXPIRE", KEYS[1], ttl);
-        return {1, index, ttl};
+        return {1, ARGV[2], ttl};
     `;
 
     this._redisConnection.defineCommand('acquireLock', {
-        numberOfKeys: 2,
+        numberOfKeys: 1,
         lua: acquireScript
     });
 
     let extendScript = `
         local ttl = tonumber(ARGV[2]);
-        local index = tonumber(ARGV[1]);
         if redis.call("HGET", KEYS[1], "index") == ARGV[1] then
             redis.call("PEXPIRE", KEYS[1], ttl);
             return {1, index, ttl};
@@ -95,12 +100,12 @@ function Lock(options) {
     });
 
     let releaseScript = `
-        local index = tonumber(ARGV[1]);
+        local index = ARGV[1];
         if redis.call("EXISTS", KEYS[1]) == 0 then
             return {1, "expired", "expired", 0};
         end;
         local data = {
-            ["index"]=tonumber(redis.call("HGET", KEYS[1], "index"))
+            ["index"]=redis.call("HGET", KEYS[1], "index")
         };
         if data.index == index then
             redis.call("DEL", KEYS[1]);
@@ -115,6 +120,48 @@ function Lock(options) {
         numberOfKeys: 1,
         lua: releaseScript
     });
+}
+
+// Cheaply generate randoms that may not be unguessable but should be random enough
+// to make it unrealistic that two contenders will get the same key for the same lock
+function generateKey() {
+    return `${Date.now()}${Math.random()}`;
+}
+
+function aquireLock(id, ttl, key, start) {
+    // Do not make it 0 ; that would mean to wait forever
+    const replicationTimeRemaining = Math.max(this._replicationTimeout - (Date.now() - start), 1);
+    const lockPath = `${this._namespace}:${id}`;
+    return this._redisConnection
+        .pipeline()
+        .acquireLock(lockPath, ttl, key)
+        .wait(this._minReplications, replicationTimeRemaining)
+        // Waiting may have taken some time which shouldn't be taken from the locks lifetime.
+        .extendLock(lockPath, key, ttl)
+        .exec()
+        .then(([[evalErr, evalResponse], [repErr, replications]]) => {
+            let error = evalErr || repErr;
+            if (error) {
+                if (error.name !== 'AbortError') {
+                    throw error;
+                }
+                // If _replicationTimeout hasn't expired yet, try again.
+                if (Date.now() - start < this._replicationTimeout) {
+                    return aquireLock.call(this, id, ttl, key, start);
+                }
+            }
+            const lock = {
+                id,
+                success: replications >= this._minReplications && !!evalResponse[0],
+                index: evalResponse[1],
+                ttl: evalResponse[2]
+            };
+            if (replications < this._minReplications) {
+                lock.replicationFailure = true;
+                this._redisConnection.releaseLock(lock);
+            }
+            return lock;
+        });
 }
 
 Object.assign(Lock.prototype, {
@@ -137,27 +184,10 @@ Object.assign(Lock.prototype, {
         if (arguments.length > 2) {
             return callbackify(this.acquireLock).apply(this, arguments);
         }
-        return this._redisConnection
-            .pipeline()
-            .acquireLock(`${this._namespace}:${id}`, `${this._namespace}index`, ttl)
-            .wait(this._minReplications, this._replicationTimeout)
-            .exec()
-            .then(([[evalErr, evalResponse], [repErr, replications]]) => {
-                if (evalErr) {
-                    throw evalErr || repErr;
-                }
-                const lock = {
-                    id,
-                    success: replications >= this._minReplications && !!evalResponse[0],
-                    index: evalResponse[1],
-                    ttl: evalResponse[2]
-                };
-                if (replications < this._minReplications) {
-                    lock.replicationFailure = true;
-                    this._redisConnection.releaseLock(lock)
-                }
-                return lock;
-            });
+        if (ttl < this._minTtl) {
+            throw new Error('ttl must be significantly longer than replicationTimeout');
+        }
+        return aquireLock.call(this, id, ttl, generateKey(), Date.now());
     },
 
     /**

--- a/test/ioredfour-test.js
+++ b/test/ioredfour-test.js
@@ -8,9 +8,9 @@ const Redis = require('ioredis');
 
 const REDIS_CONFIG = 'redis://localhost:6379/11';
 
-// We need an unique key just in case a previous test run ended with an exception
+// We need an unique key just in case a previous test ended with an exception
 // and testing keys were not immediately deleted (these expire automatically after a while)
-let testKey = 'TEST:' + Date.now();
+let testKey;
 
 describe('lock', function () {
     this.timeout(10000); //eslint-disable-line no-invalid-this
@@ -24,7 +24,7 @@ describe('lock', function () {
             namespace: 'testLock',
             minReplications: 0,
         });
-
+        testKey = 'TEST:' + Date.now() + Math.random();
         done();
     });
 
@@ -32,14 +32,14 @@ describe('lock', function () {
         const lock = await testLock.acquireLock(testKey, 60 * 100);
         expect(lock.success).to.equal(true);
         expect(lock.id).to.equal(testKey);
-        expect(lock.index).to.be.above(0);
+        expect(lock.index).to.be.a('string').with.length.above(0);
 
         const invalidLock = await testLock.acquireLock(testKey, 60 * 100);
         expect(invalidLock.success).to.equal(false);
 
         const invalidRelease = await testLock.releaseLock({
             id: testKey,
-            index: -10
+            index: '123'
         });
         expect(invalidRelease.success).to.equal(false);
 


### PR DESCRIPTION
As mentioned in the other PRs discussion, the library could re-attempt to get a lock if synchronization fails within replicationTimeout. This is implemented in this PR. 
Also I realized there was a flaw, which is that while waiting for replication, the already acquired lock in the primary is loosing it's time-to-live and may actually already have completely expired before the WAIT finishes. To mitigate that:
- There is now a requirement that the TTL is 'significantly longer' (currently 1.5x) than replicationTimeout. So that when WAIT takes nearly replicationTimeout, we can be sure the lock is actually still alive
- After waiting the lock is immediately 'extended', ie gets it's full TTL again.

This implies:
- Resetting the TTL requires knowing the key before we enter the
pipeline, which means we can't have it generated by redis during the
aquireLock anymore. It needs to be generated client-side now, which I do by a cheap time + random.
- the acquireScript needs to extend the TTL if it's already owned, since
we may be re-trying after a failed WAIT. At which point we may or may
not have the lock in the current master already. And we'll need to be
sure that the ttl will survive the next WAIT. This implicitly gives
aquireLock the ability to extend a lock.

Because acquireLock now actually extends a previously held lock, the same implementation is now used for the extendLock function, the difference being that extendLock requires to have the key in advance.